### PR TITLE
vlingo-http-frontservice has Bootstrap, UserResource and ProfileResource with Fluent API as example

### DIFF
--- a/vlingo-http-frontservice/.editorconfig
+++ b/vlingo-http-frontservice/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.java]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/vlingo-http-frontservice/pom.xml
+++ b/vlingo-http-frontservice/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.vlingo</groupId>
   <artifactId>vlingo-http-frontservice</artifactId>
-  <version>0.7.2</version>
+  <version>0.7.3</version>
   <packaging>jar</packaging>
   <name>vlingo-http-frontservice</name>
   <description>Example of vlingo/http public service.</description>
@@ -70,27 +70,27 @@
     <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-common</artifactId>
-      <version>0.7.2</version>
+      <version>0.7.3</version>
     </dependency>
     <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-actors</artifactId>
-      <version>0.7.2</version>
+      <version>0.7.3</version>
     </dependency>
     <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-http</artifactId>
-      <version>0.7.2</version>
+      <version>0.7.3</version>
     </dependency>
     <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-symbio</artifactId>
-      <version>0.7.2</version>
+      <version>0.7.3</version>
     </dependency>
     <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-lattice</artifactId>
-      <version>0.7.2</version>
+      <version>0.7.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/infra/BootstrapWithFluentAPI.java
+++ b/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/infra/BootstrapWithFluentAPI.java
@@ -1,0 +1,85 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.frontservice.infra;
+
+import io.vlingo.actors.World;
+import io.vlingo.frontservice.infra.persistence.CommandModelStoreProvider;
+import io.vlingo.frontservice.infra.persistence.QueryModelStoreProvider;
+import io.vlingo.frontservice.infra.projection.ProjectionDispatcherProvider;
+import io.vlingo.frontservice.resource.ProfileResourceWithFluentAPI;
+import io.vlingo.frontservice.resource.UserResourceWithFluentAPI;
+import io.vlingo.http.resource.Resources;
+import io.vlingo.http.resource.Server;
+
+import static io.vlingo.http.resource.Configuration.Sizing;
+import static io.vlingo.http.resource.Configuration.Timing;
+
+public class BootstrapWithFluentAPI {
+  private static BootstrapWithFluentAPI instance;
+  public final Server server;
+
+  //  public static final Bootstrap testInstance() {
+//    if (instance == null) instance = new Bootstrap(true);
+//    return instance;
+//  }
+  public final World world;
+
+  private BootstrapWithFluentAPI() {
+    this.world = World.startWithDefaults("frontservice");
+
+    QueryModelStoreProvider.using(world.stage());
+
+    CommandModelStoreProvider.using(world.stage(), ProjectionDispatcherProvider.using(world.stage()).textStateStoreDispatcher);
+
+    final UserResourceWithFluentAPI userResource = new UserResourceWithFluentAPI(world);
+    final ProfileResourceWithFluentAPI profileResource = new ProfileResourceWithFluentAPI(world);
+
+    final Resources resources = Resources.are(userResource.routes(), profileResource.routes());
+
+    this.server = Server.startWith(world.stage(), resources, 8081, Sizing.define(), Timing.define());
+
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        if (instance != null) {
+          instance.server.stop();
+
+          System.out.println("\n");
+          System.out.println("=======================");
+          System.out.println("Stopping frontservice.");
+          System.out.println("=======================");
+          pause();
+        }
+      }
+    });
+  }
+
+  public static final BootstrapWithFluentAPI instance() {
+    if (instance == null) instance = new BootstrapWithFluentAPI();
+    return instance;
+  }
+
+  public static final void terminateTestInstance() {
+    instance = null;
+  }
+
+  public static void main(final String[] args) throws Exception {
+    System.out.println("=======================");
+    System.out.println("frontservice: started.");
+    System.out.println("=======================");
+    BootstrapWithFluentAPI.instance();
+  }
+
+  private void pause() {
+    try {
+      Thread.sleep(1000L);
+    } catch (Exception e) {
+      // ignore
+    }
+  }
+}

--- a/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/infra/persistence/QueriesActor.java
+++ b/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/infra/persistence/QueriesActor.java
@@ -16,8 +16,8 @@ import io.vlingo.common.Completes;
 import io.vlingo.frontservice.data.ProfileData;
 import io.vlingo.frontservice.data.UserData;
 import io.vlingo.symbio.State;
+import io.vlingo.symbio.store.Result;
 import io.vlingo.symbio.store.state.StateStore.ReadResultInterest;
-import io.vlingo.symbio.store.state.StateStore.Result;
 import io.vlingo.symbio.store.state.TextStateStore;
 
 public class QueriesActor extends Actor implements Queries, ReadResultInterest<String> {

--- a/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/infra/projection/UserProjectionActor.java
+++ b/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/infra/projection/UserProjectionActor.java
@@ -20,8 +20,8 @@ import io.vlingo.lattice.model.projection.Projection;
 import io.vlingo.lattice.model.projection.ProjectionControl;
 import io.vlingo.symbio.State;
 import io.vlingo.symbio.State.TextState;
+import io.vlingo.symbio.store.Result;
 import io.vlingo.symbio.store.state.StateStore.ReadResultInterest;
-import io.vlingo.symbio.store.state.StateStore.Result;
 import io.vlingo.symbio.store.state.StateStore.WriteResultInterest;
 import io.vlingo.symbio.store.state.TextStateStore;
 

--- a/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/resource/ProfileResourceWithFluentAPI.java
+++ b/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/resource/ProfileResourceWithFluentAPI.java
@@ -1,0 +1,75 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.frontservice.resource;
+
+import io.vlingo.actors.AddressFactory;
+import io.vlingo.actors.Definition;
+import io.vlingo.actors.Stage;
+import io.vlingo.actors.World;
+import io.vlingo.common.Completes;
+import io.vlingo.frontservice.data.ProfileData;
+import io.vlingo.frontservice.infra.persistence.Queries;
+import io.vlingo.frontservice.infra.persistence.QueryModelStoreProvider;
+import io.vlingo.frontservice.model.Profile;
+import io.vlingo.frontservice.model.ProfileEntity;
+import io.vlingo.http.Response;
+import io.vlingo.http.resource.Resource;
+
+import static io.vlingo.common.serialization.JsonSerialization.serialized;
+import static io.vlingo.http.Response.Status.*;
+import static io.vlingo.http.ResponseHeader.*;
+import static io.vlingo.http.resource.ResourceBuilder.*;
+
+public class ProfileResourceWithFluentAPI {
+  private final AddressFactory addressFactory;
+  private final Queries queries;
+  private final Stage stage;
+
+  public ProfileResourceWithFluentAPI(final World world) {
+    this.addressFactory = world.addressFactory();
+    this.stage = world.stage();
+    this.queries = QueryModelStoreProvider.instance().queries;
+  }
+
+  public Completes<Response> define(final String userId, final ProfileData profileData) {
+    return stage.actorOf(addressFactory.findableBy(Integer.parseInt(userId)), Profile.class)
+      .andThenInto(profile -> queries.profileOf(userId))
+      .andThenInto(data -> Completes.withSuccess(Response.of(Ok, headers(of(Location, profileLocation(userId))), serialized(data))))
+      .otherwise(noProfile -> {
+        final Profile.ProfileState profileState =
+          Profile.from(
+            userId,
+            profileData.twitterAccount,
+            profileData.linkedInAccount,
+            profileData.website);
+        stage.actorFor(Definition.has(ProfileEntity.class, Definition.parameters(profileState)), Profile.class);
+        return Response.of(Created, serialized(ProfileData.from(profileState)));
+      });
+  }
+
+  public Completes<Response> query(final String userId) {
+    return queries.profileOf(userId)
+      .andThenInto(data -> Completes.withSuccess(Response.of(Ok, serialized(data))))
+      .otherwise(noData -> Response.of(NotFound, profileLocation(userId)));
+  }
+
+  private String profileLocation(final String userId) {
+    return "/users/" + userId + "/profile";
+  }
+
+  public Resource routes() {
+    return resource("profile resource fluent api",
+      put("/users/{userId}/profile")
+        .param(String.class)
+        .body(ProfileData.class)
+        .handle(this::define),
+      get("/users/{userId}/profile")
+        .param(String.class)
+        .handle(this::query));
+  }
+}

--- a/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/resource/UserResourceWithFluentAPI.java
+++ b/vlingo-http-frontservice/src/main/java/io/vlingo/frontservice/resource/UserResourceWithFluentAPI.java
@@ -1,0 +1,100 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.frontservice.resource;
+
+import io.vlingo.actors.*;
+import io.vlingo.common.Completes;
+import io.vlingo.frontservice.data.ContactData;
+import io.vlingo.frontservice.data.NameData;
+import io.vlingo.frontservice.data.UserData;
+import io.vlingo.frontservice.infra.persistence.Queries;
+import io.vlingo.frontservice.infra.persistence.QueryModelStoreProvider;
+import io.vlingo.frontservice.model.*;
+import io.vlingo.http.Response;
+import io.vlingo.http.resource.Resource;
+
+import static io.vlingo.common.serialization.JsonSerialization.serialized;
+import static io.vlingo.http.Response.Status.*;
+import static io.vlingo.http.ResponseHeader.*;
+import static io.vlingo.http.resource.ResourceBuilder.*;
+
+public class UserResourceWithFluentAPI {
+  private final AddressFactory addressFactory;
+  private final Queries queries;
+  private final Stage stage;
+
+  public UserResourceWithFluentAPI(final World world) {
+    this.addressFactory = world.addressFactory();
+    this.stage = world.stage();
+    this.queries = QueryModelStoreProvider.instance().queries;
+  }
+
+  public Completes<Response> register(final UserData userData) {
+    final Address userAddress = addressFactory.uniquePrefixedWith("u-");
+
+    final User.UserState userState =
+      User.from(
+        userAddress.idString(),
+        Name.from(userData.nameData.given, userData.nameData.family),
+        Contact.from(userData.contactData.emailAddress, userData.contactData.telephoneNumber),
+        Security.from(userData.publicSecurityToken));
+
+    stage.actorFor(Definition.has(UserEntity.class, Definition.parameters(userState)), User.class, userAddress);
+
+    return Completes.withSuccess(Response.of(Created, headers(of(Location, userLocation(userState.id))), serialized(UserData.from(userState))));
+  }
+
+  public Completes<Response> changeContact(final String userId, final ContactData contactData) {
+    return stage.actorOf(addressFactory.findableBy(addressFactory.from(userId)), User.class)
+      .andThenInto(user -> user.withContact(new Contact(contactData.emailAddress, contactData.telephoneNumber)))
+      .andThenInto(userState -> Completes.withSuccess(Response.of(Ok, serialized(UserData.from(userState)))))
+      .otherwise(noUser -> Response.of(NotFound, userLocation(userId)));
+  }
+
+  public Completes<Response> changeName(final String userId, final NameData nameData) {
+    return stage.actorOf(addressFactory.findableBy(addressFactory.from(userId)), User.class)
+      .andThenInto(user -> user.withName(new Name(nameData.given, nameData.family)))
+      .andThenInto(userState -> Completes.withSuccess(Response.of(Ok, serialized(UserData.from(userState)))))
+      .otherwise(noUser -> Response.of(NotFound, userLocation(userId)));
+  }
+
+  public Completes<Response> queryUser(final String userId) {
+    return queries.userDataOf(userId)
+      .andThenInto(data -> Completes.withSuccess(Response.of(Ok, serialized(data))))
+      .otherwise(noData -> Response.of(NotFound, userLocation(userId)));
+  }
+
+  public Completes<Response> queryUsers() {
+    return queries.usersData()
+      .andThenInto(data -> Completes.withSuccess(Response.of(Ok, serialized(data))));
+  }
+
+  private String userLocation(final String userId) {
+    return "/users/" + userId;
+  }
+
+  public Resource routes() {
+    return resource("user resource fluent api",
+      post("/users")
+        .body(UserData.class)
+        .handle(this::register),
+      patch("/users/{userId}/contact")
+        .param(String.class)
+        .body(ContactData.class)
+        .handle(this::changeContact),
+      patch("/users/{userId}/name")
+        .param(String.class)
+        .body(NameData.class)
+        .handle(this::changeName),
+      get("/users/{userId}")
+        .param(String.class)
+        .handle(this::queryUser),
+      get("/users")
+        .handle(this::queryUsers));
+  }
+}


### PR DESCRIPTION
I've duplicated the classes appending `withFulentAPI` as class name. I don't like how it looks, how could we change that? Should we have two branches?