### PR TITLE
initial commit of competing consumers; test does not pass (open quest…

### DIFF
--- a/vlingo-reactive-messaging-patterns/pom.xml
+++ b/vlingo-reactive-messaging-patterns/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-actors</artifactId>
-      <version>0.7.2</version>
+      <version>0.7.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.collections</groupId>

--- a/vlingo-reactive-messaging-patterns/src/main/java/io/vlingo/reactive/messaging/patterns/competingconsumer/WorkConsumer.java
+++ b/vlingo-reactive-messaging-patterns/src/main/java/io/vlingo/reactive/messaging/patterns/competingconsumer/WorkConsumer.java
@@ -1,0 +1,13 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.reactive.messaging.patterns.competingconsumer;
+/**
+ * WorkConsumer is responsible for consuming a {@link WorkItem}
+ */
+public interface WorkConsumer {
+  void consumeWork(final WorkItem item);
+}

--- a/vlingo-reactive-messaging-patterns/src/main/java/io/vlingo/reactive/messaging/patterns/competingconsumer/WorkConsumerActor.java
+++ b/vlingo-reactive-messaging-patterns/src/main/java/io/vlingo/reactive/messaging/patterns/competingconsumer/WorkConsumerActor.java
@@ -1,0 +1,29 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.reactive.messaging.patterns.competingconsumer;
+
+import io.vlingo.actors.Actor;
+import io.vlingo.actors.testkit.TestUntil;
+/**
+ * WorkConsumerActor
+ */
+public class WorkConsumerActor extends Actor implements WorkConsumer {
+  
+  private final TestUntil until;
+
+  public WorkConsumerActor(final TestUntil until) {
+    super();
+    this.until = until;
+  }
+
+  /* @see io.vlingo.reactive.messaging.patterns.competingconsumer.WorkConsumer#consumeWork(io.vlingo.reactive.messaging.patterns.competingconsumer.WorkItem) */
+  @Override
+  public void consumeWork(final WorkItem item) {
+    logger().log(this + " consumed: " + item);
+    until.happened();
+  }
+}

--- a/vlingo-reactive-messaging-patterns/src/main/java/io/vlingo/reactive/messaging/patterns/competingconsumer/WorkItem.java
+++ b/vlingo-reactive-messaging-patterns/src/main/java/io/vlingo/reactive/messaging/patterns/competingconsumer/WorkItem.java
@@ -1,0 +1,28 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.reactive.messaging.patterns.competingconsumer;
+/**
+ * WorkItem
+ */
+public class WorkItem {
+  
+  private final int id;
+  
+  public WorkItem(final int id) {
+    this.id = id;
+  }
+  
+  public int id() {
+    return id;
+  }
+
+  /* @see java.lang.Object#toString() */
+  @Override
+  public String toString() {
+    return "WorkItem[id=" + id + "]";
+  }
+}

--- a/vlingo-reactive-messaging-patterns/src/main/java/io/vlingo/reactive/messaging/patterns/competingconsumer/WorkRouterActor.java
+++ b/vlingo-reactive-messaging-patterns/src/main/java/io/vlingo/reactive/messaging/patterns/competingconsumer/WorkRouterActor.java
@@ -1,0 +1,37 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.reactive.messaging.patterns.competingconsumer;
+
+import io.vlingo.actors.Definition;
+import io.vlingo.actors.RoundRobinRoutingStrategy;
+import io.vlingo.actors.Router;
+import io.vlingo.actors.RouterSpecification;
+import io.vlingo.actors.testkit.TestUntil;
+/**
+ * WorkRouterActor
+ */
+public class WorkRouterActor extends Router implements WorkConsumer {
+  
+  public WorkRouterActor(final int poolSize, final TestUntil testUntil) {
+    super(
+      new RouterSpecification(
+        poolSize,
+        Definition.has(WorkConsumerActor.class, Definition.parameters(testUntil)),
+        WorkConsumer.class
+      ),
+      new RoundRobinRoutingStrategy()
+    );
+  }
+  
+  /* @see io.vlingo.reactive.messaging.patterns.competingconsumer.WorkConsumer#consume(io.vlingo.reactive.messaging.patterns.competingconsumer.WorkItem) */
+  @Override
+  public void consumeWork(final WorkItem item) {
+    computeRouting(item)
+        .routeesAs(WorkConsumer.class)
+        .forEach(routee -> routee.consumeWork(item));
+  }
+}

--- a/vlingo-reactive-messaging-patterns/src/test/java/io/vlingo/reactive/messaging/patterns/competingconsumer/CompetingConsumerTest.java
+++ b/vlingo-reactive-messaging-patterns/src/test/java/io/vlingo/reactive/messaging/patterns/competingconsumer/CompetingConsumerTest.java
@@ -1,0 +1,36 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.reactive.messaging.patterns.competingconsumer;
+/**
+ * CompetingConsumerTest provides an example of implementing
+ * and using a vlingo Router.
+ */
+import org.junit.Test;
+
+import io.vlingo.actors.Definition;
+import io.vlingo.actors.World;
+import io.vlingo.actors.testkit.TestUntil;
+
+public class CompetingConsumerTest {
+
+  @Test
+  public void testThatConsumersCompete() {
+    final World world = World.startWithDefaults("competing-consumer-test");
+    final int poolSize = 4;
+    final int messagesToSend = 8;
+    final TestUntil until = TestUntil.happenings(messagesToSend);
+    final WorkConsumer workConsumer = world.actorFor(
+            Definition.has(WorkRouterActor.class, Definition.parameters(poolSize, until)),
+            WorkConsumer.class);
+    
+    for (int i = 0; i < messagesToSend; i++) {
+      workConsumer.consumeWork(new WorkItem(i));
+    }
+    
+    until.completes();
+  }
+}


### PR DESCRIPTION
@VaughnVernon something odd is going on that I am not seeing. Compare io.vlingo.actors.RoundRobinRouterTest to io.vlingo.reactive.messaging.patterns.competingconsumer.CompetingConsumerTest. If you compare the test case, the Router subclass, the routee Actor classes, etc. they are almost the same code. But they behave differently. If you run RoundRobinRouterTest, the console output shows that the router does route in a round robin fashion (using actor id's to track who gets what message). But if you run CompetingConsumerTest, the router routes correctly for the first "round" (messages 1 - 4), but then routes every message to the first/same WorkConsumerActor for messages 5 - 8. I'm obviously missing some little difference. Maybe you can see it... Thanks.