### PR TITLE
Corrected minor bug in ecommerce example

### DIFF
--- a/vlingo-ecommerce/src/main/java/io/vlingo/examples/ecommerce/model/CartActor.java
+++ b/vlingo-ecommerce/src/main/java/io/vlingo/examples/ecommerce/model/CartActor.java
@@ -80,7 +80,7 @@ public class CartActor extends EventSourced implements Cart {
     }
 
     private void applyQuantityChange(final CartEvents.ProductQuantityChangeEvent e) {
-        state = state.productQuantityChange(e.productId, e.newQuantity);
+        state = state.productQuantityChange(e.productId, e.quantityChange);
     }
 
     private void applyAllItemsRemoved(final CartEvents.AllItemsRemovedEvent e) {

--- a/vlingo-ecommerce/src/test/java/io/vlingo/examples/ecommerce/CartResourceShould.java
+++ b/vlingo-ecommerce/src/test/java/io/vlingo/examples/ecommerce/CartResourceShould.java
@@ -89,5 +89,14 @@ public class CartResourceShould {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body(is(equalTo("[{\"productId\":{\"id\":\"pid1\"},\"quantity\":1}]")));
+
+        baseGiven()
+                .when()
+                .body("{operation: \"add\"}")
+                .patch(cartUrl + "/pid1")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is(equalTo("[{\"productId\":{\"id\":\"pid1\"},\"quantity\":2}]")));
     }
 }


### PR DESCRIPTION
When adding a product multiple times to the cart in the ecommerce example the quantity was wrongly calculated. Corrected applyQuantityChange method to add quantityChange instead of newQuantity and updated test. 