### PR TITLE
[vlingo-ecommerce] Update the expected serialized response to reflect the actual response

### DIFF
--- a/vlingo-ecommerce/src/test/java/io/vlingo/examples/ecommerce/CartResourceShould.java
+++ b/vlingo-ecommerce/src/test/java/io/vlingo/examples/ecommerce/CartResourceShould.java
@@ -86,7 +86,7 @@ public class CartResourceShould {
         String summaryUrl = String.format("/user/%d/cartSummary", userIdForCart);
         String cartId = getCartId(cartUrl);
 
-        String expectedResponse = String.format("{\"userId\":\"100\",\"cartId\":\"%s\",\"numberOfItems\":\"0\"}", cartId);
+        String expectedResponse = String.format("{\"userId\":\"100\",\"cartId\":\"%s\",\"numberOfItems\":0}", cartId);
         baseGiven()
                 .when()
                 .get(summaryUrl)
@@ -104,7 +104,7 @@ public class CartResourceShould {
         // summaryUrl = String.format("/user/%d/cartSummary", userIdForCart);
         // cartId = getCartId(cartUrl);
 
-        expectedResponse = String.format("{\"userId\":\"100\",\"cartId\":\"%s\",\"numberOfItems\":\"0\"}", cartId);
+        expectedResponse = String.format("{\"userId\":\"100\",\"cartId\":\"%s\",\"numberOfItems\":0}", cartId);
 
         baseGiven()
                 .when()


### PR DESCRIPTION
Currently, the tests are failing:

```
mvn clean test -U -pl vlingo-ecommerce
```

```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.023 s <<< FAILURE! - in io.vlingo.examples.ecommerce.CartResourceShould
[ERROR] userCartSummary_created(io.vlingo.examples.ecommerce.CartResourceShould)  Time elapsed: 0.149 s  <<< FAILURE!
java.lang.AssertionError:
1 expectation failed.
Response body doesn't match expectation.
Expected: is "{\"userId\":\"100\",\"cartId\":\"332\",\"numberOfItems\":\"0\"}"
  Actual: {"userId":"100","cartId":"332","numberOfItems":0}

        at io.vlingo.examples.ecommerce.CartResourceShould.userCartSummary_created(CartResourceShould.java:96)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   CartResourceShould.userCartSummary_created:96 1 expectation failed.
Response body doesn't match expectation.
Expected: is "{\"userId\":\"100\",\"cartId\":\"332\",\"numberOfItems\":\"0\"}"
  Actual: {"userId":"100","cartId":"332","numberOfItems":0}

[INFO]
[ERROR] Tests run: 6, Failures: 1, Errors: 0, Skipped: 0
```