### PR TITLE
Update the distributed ping pong example for vlingo-lattice 1.2.21

### DIFF
--- a/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PingPongRefereeActor.java
+++ b/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PingPongRefereeActor.java
@@ -1,12 +1,12 @@
 package io.vlingo.pingpong.domain.impl;
 
+import io.vlingo.actors.Actor;
 import io.vlingo.actors.Definition;
-import io.vlingo.actors.StatelessGridActor;
 import io.vlingo.common.Completes;
 import io.vlingo.pingpong.domain.PingPongReferee;
 import io.vlingo.pingpong.domain.Pinger;
 
-public class PingPongRefereeActor extends StatelessGridActor implements PingPongReferee {
+public class PingPongRefereeActor extends Actor implements PingPongReferee {
 
   @Override
   public Completes<Pinger> whistle(String name) {

--- a/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PingerActor.java
+++ b/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PingerActor.java
@@ -1,10 +1,10 @@
 package io.vlingo.pingpong.domain.impl;
 
-import io.vlingo.actors.StatelessGridActor;
+import io.vlingo.actors.Actor;
 import io.vlingo.pingpong.domain.Pinger;
 import io.vlingo.pingpong.domain.Ponger;
 
-public class PingerActor extends StatelessGridActor implements Pinger {
+public class PingerActor extends Actor implements Pinger {
 
   private Pinger self;
 

--- a/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PongerActor.java
+++ b/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PongerActor.java
@@ -1,10 +1,10 @@
 package io.vlingo.pingpong.domain.impl;
 
-import io.vlingo.actors.StatelessGridActor;
+import io.vlingo.actors.Actor;
 import io.vlingo.pingpong.domain.Pinger;
 import io.vlingo.pingpong.domain.Ponger;
 
-public class PongerActor extends StatelessGridActor implements Ponger {
+public class PongerActor extends Actor implements Ponger {
 
   private final Ponger self;
 


### PR DESCRIPTION
The `vlingo-distributed-ping-pong` example doesn't compile as the `StatelessGridActor` was removed in https://github.com/vlingo/vlingo-lattice/commit/6cf6fb65b1b117bb5fa70124ad84ffa71faf293d#diff-16297aa4e59338d999a0c2bfbc94867a

Documentation needs an update too.

Actors in this example won't be actually distributed due to https://github.com/vlingo/vlingo-lattice/pull/26