### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: java
+dist: trusty
+
+before_install:
+  - rm -rf $HOME/.m2/repository/io/vlingo
+
+script:
+  - mvn clean test -U
+
+before_cache:
+  - rm -rf $HOME/.m2/repository/io/vlingo
+cache:
+  directories:
+    - $HOME/.m2/repository

--- a/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PingPongRefereeActor.java
+++ b/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PingPongRefereeActor.java
@@ -1,12 +1,12 @@
 package io.vlingo.pingpong.domain.impl;
 
+import io.vlingo.actors.Actor;
 import io.vlingo.actors.Definition;
-import io.vlingo.actors.StatelessGridActor;
 import io.vlingo.common.Completes;
 import io.vlingo.pingpong.domain.PingPongReferee;
 import io.vlingo.pingpong.domain.Pinger;
 
-public class PingPongRefereeActor extends StatelessGridActor implements PingPongReferee {
+public class PingPongRefereeActor extends Actor implements PingPongReferee {
 
   @Override
   public Completes<Pinger> whistle(String name) {

--- a/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PingerActor.java
+++ b/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PingerActor.java
@@ -1,10 +1,10 @@
 package io.vlingo.pingpong.domain.impl;
 
-import io.vlingo.actors.StatelessGridActor;
+import io.vlingo.actors.Actor;
 import io.vlingo.pingpong.domain.Pinger;
 import io.vlingo.pingpong.domain.Ponger;
 
-public class PingerActor extends StatelessGridActor implements Pinger {
+public class PingerActor extends Actor implements Pinger {
 
   private Pinger self;
 

--- a/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PongerActor.java
+++ b/vlingo-distributed-ping-pong/src/main/java/io/vlingo/pingpong/domain/impl/PongerActor.java
@@ -1,10 +1,10 @@
 package io.vlingo.pingpong.domain.impl;
 
-import io.vlingo.actors.StatelessGridActor;
+import io.vlingo.actors.Actor;
 import io.vlingo.pingpong.domain.Pinger;
 import io.vlingo.pingpong.domain.Ponger;
 
-public class PongerActor extends StatelessGridActor implements Ponger {
+public class PongerActor extends Actor implements Ponger {
 
   private final Ponger self;
 

--- a/vlingo-ecommerce/src/test/java/io/vlingo/examples/ecommerce/CartResourceShould.java
+++ b/vlingo-ecommerce/src/test/java/io/vlingo/examples/ecommerce/CartResourceShould.java
@@ -86,7 +86,7 @@ public class CartResourceShould {
         String summaryUrl = String.format("/user/%d/cartSummary", userIdForCart);
         String cartId = getCartId(cartUrl);
 
-        String expectedResponse = String.format("{\"userId\":\"100\",\"cartId\":\"%s\",\"numberOfItems\":\"0\"}", cartId);
+        String expectedResponse = String.format("{\"userId\":\"100\",\"cartId\":\"%s\",\"numberOfItems\":0}", cartId);
         baseGiven()
                 .when()
                 .get(summaryUrl)
@@ -104,7 +104,7 @@ public class CartResourceShould {
         // summaryUrl = String.format("/user/%d/cartSummary", userIdForCart);
         // cartId = getCartId(cartUrl);
 
-        expectedResponse = String.format("{\"userId\":\"100\",\"cartId\":\"%s\",\"numberOfItems\":\"0\"}", cartId);
+        expectedResponse = String.format("{\"userId\":\"100\",\"cartId\":\"%s\",\"numberOfItems\":0}", cartId);
 
         baseGiven()
                 .when()

--- a/vlingo-platform-patterns/src/test/java/io/vlingo/entity/object/OrganizationEntityTest.java
+++ b/vlingo-platform-patterns/src/test/java/io/vlingo/entity/object/OrganizationEntityTest.java
@@ -67,6 +67,7 @@ public class OrganizationEntityTest {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void setUp() throws Exception {
     grid = Grid.start("object-entity-test", Configuration.define(), ClusterProperties.oneNode(), "node1");
+    grid.quorumAchieved();
     objectStore = grid.actorFor(ObjectStore.class, InMemoryObjectStoreActor.class, new MockDispatcher());
     registry = new ObjectTypeRegistry(grid.world());
 

--- a/vlingo-platform-patterns/src/test/java/io/vlingo/entity/sourced/OrganizationEntityTest.java
+++ b/vlingo-platform-patterns/src/test/java/io/vlingo/entity/sourced/OrganizationEntityTest.java
@@ -65,6 +65,7 @@ public class OrganizationEntityTest {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void setUp() throws Exception {
     grid = Grid.start("sourced-entity-test", Configuration.define(), ClusterProperties.oneNode(), "node1");
+    grid.quorumAchieved();
     journal = grid.actorFor(Journal.class, InMemoryJournalActor.class, new MockDispatcher());
     registry = new SourcedTypeRegistry(grid.world());
 

--- a/vlingo-platform-patterns/src/test/java/io/vlingo/entity/stateful/OrganizationEntityTest.java
+++ b/vlingo-platform-patterns/src/test/java/io/vlingo/entity/stateful/OrganizationEntityTest.java
@@ -67,6 +67,7 @@ public class OrganizationEntityTest {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void setUp() throws Exception {
     grid = Grid.start("stateful-entity-test", Configuration.define(), ClusterProperties.oneNode(), "node1");
+    grid.quorumAchieved();
     stateStore = grid.actorFor(StateStore.class, InMemoryStateStoreActor.class, Arrays.asList(new MockDispatcher()));
     registry = new StatefulTypeRegistry(grid.world());
 

--- a/vlingo-reactive-messaging-patterns/src/test/java/io/vlingo/reactive/messaging/patterns/competingconsumer/CompetingConsumerTest.java
+++ b/vlingo-reactive-messaging-patterns/src/test/java/io/vlingo/reactive/messaging/patterns/competingconsumer/CompetingConsumerTest.java
@@ -29,12 +29,12 @@ public class CompetingConsumerTest {
     final CompetingConsumerResults results = new CompetingConsumerResults();
     final WorkConsumer workConsumer =
             world.actorFor(WorkConsumer.class, WorkRouterActor.class, poolSize, results);
+    final AccessSafely access = results.afterCompleting(messagesToSend);
 
     for (int i = 0; i < messagesToSend; i++) {
       workConsumer.consumeWork(new WorkItem(i));
     }
 
-    final AccessSafely access = results.afterCompleting(messagesToSend);
     Assert.assertEquals(8, (int) access.readFrom("afterItemConsumedCount"));
   }
 }


### PR DESCRIPTION
Passing build: https://travis-ci.com/github/jakzal/vlingo-examples/builds/167818336

Travis will need to be enabled for this repository, so the tests are run on pushes and pull requests. 
Since tests are run against SNAPSHOTS I think it's worth to additionally configure Travis to run daily (there's a CRON config in their UI).

Summary of changes:

* Add Travis CI configuration
* Update the distributed ping pong example for lattice 1.2.21 (remove the use of StatelessGridActor)
* Fix tests:
  * Update the expected response in the vlingo-ecommerce example
  * Define AccessSafely before work is consumed in the competingconsumer example
  * Prevent several tests from falling into an endless loop while trying to achieve cluster quorum

<img width="603" alt="image" src="https://user-images.githubusercontent.com/190447/82698798-62b5d300-9c63-11ea-9fea-f4db94c9107a.png">
