### PR TITLE
Update the actors kotlin playground example to work with the latest vlingo api

### DIFF
--- a/vlingo-actors-playground-kotlin/src/test/kotlin/io/vlingo/PingPongTest.kt
+++ b/vlingo-actors-playground-kotlin/src/test/kotlin/io/vlingo/PingPongTest.kt
@@ -11,14 +11,13 @@ class PingPongTest {
     fun testPlayPingPong() {
         val world:World = World.startWithDefaults("com.dfp")
         val until:TestUntil = TestUntil.happenings(1)
-        val pinger:Pinger = world.actorFor(Definition.has(PingerActor::class.java, Definition.parameters(until)), Pinger::class.java)
-        val ponger:Ponger = world.actorFor(Definition.has(PongerActor::class.java, Definition.NoParameters), Ponger::class.java)
+        val pinger:Pinger = world.actorFor(Pinger::class.java, PingerActor::class.java, until)
+        val ponger:Ponger = world.actorFor(Ponger::class.java, PongerActor::class.java)
 
         pinger.ping(ponger)
 
         until.completes()
 
         world.terminate()
-
     }
 }


### PR DESCRIPTION
Otherwise tests are failing with:

```
[ERROR] /vlingo-examples/vlingo-actors-playground-kotlin/src/test/kotlin/io/vlingo/PingPongTest.kt: (14, 35) 
None of the following functions can be called with the arguments supplied:                                                                                                                                        public open fun <T : Any!> actorFor(p0: Class<Pinger!>!, p1: Definition!): Pinger! defined in io.vlingo.actors.World
public open fun <T : Any!> actorFor(p0: Class<Pinger!>!, p1: Class<out Actor!>!, vararg p2: Any!): Pinger! defined in io.vlingo.actors.World                                 public open fun actorFor(p0: Array<(out) Class<*>!>!, p1: Definition!): Protocols! defined in io.vlingo.actors.World
public open fun actorFor(p0: Array<(out) Class<*>!>!, p1: Class<out Actor!>!, vararg p2: Any!): Protocols! defined in io.vlingo.actors.World                                 
[ERROR] /vlingo-examples/vlingo-actors-playground-kotlin/src/test/kotlin/io/vlingo/PingPongTest.kt: (15, 35) 
None of the following functions can be called with the arguments supplied:                                                                                                                                        public open fun <T : Any!> actorFor(p0: Class<Ponger!>!, p1: Definition!): Ponger! defined in io.vlingo.actors.World
public open fun <T : Any!> actorFor(p0: Class<Ponger!>!, p1: Class<out Actor!>!, vararg p2: Any!): Ponger! defined in io.vlingo.actors.World                                 public open fun actorFor(p0: Array<(out) Class<*>!>!, p1: Definition!): Protocols! defined in io.vlingo.actors.World
public open fun actorFor(p0: Array<(out) Class<*>!>!, p1: Class<out Actor!>!, vararg p2: Any!): Protocols! defined in io.vlingo.actors.World
```