### PR TITLE
Do not rely on global state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2-repository
 
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots clean test -e -Pdefault,extended
+        run: mvn --batch-mode --update-snapshots clean test -e -Pdefault,extended,snapshot-build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <module>vlingo-iddd-agilepm</module>
         <module>vlingo-iddd-collaboration</module>
         <module>vlingo-kubernetes-cluster</module>
+        <module>vlingo-petclinic</module>
         <module>vlingo-reactive-messaging-patterns</module>
         <module>vlingo-simgui-mediator</module>
         <module>vlingo-platform-patterns</module>

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/Bootstrap.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/Bootstrap.java
@@ -35,14 +35,14 @@ public class Bootstrap {
 
     final SourcedTypeRegistry sourcedTypeRegistry = new SourcedTypeRegistry(world);
     final StatefulTypeRegistry statefulTypeRegistry = new StatefulTypeRegistry(world);
-    QueryModelStateStoreProvider.using(stage, statefulTypeRegistry);
-    CommandModelJournalProvider.using(stage, sourcedTypeRegistry, ProjectionDispatcherProvider.using(stage).storeDispatcher);
+    final QueryModelStateStoreProvider queryModelStateStoreProvider = QueryModelStateStoreProvider.using(stage, statefulTypeRegistry);
+    CommandModelJournalProvider.using(stage, sourcedTypeRegistry, ProjectionDispatcherProvider.using(stage, queryModelStateStoreProvider).storeDispatcher);
 
-    final PetResource petResource = new PetResource(stage);
-    final AnimalTypeResource animalTypeResource = new AnimalTypeResource(stage);
-    final SpecialtyTypeResource specialtyTypeResource = new SpecialtyTypeResource(stage);
-    final ClientResource clientResource = new ClientResource(stage);
-    final VeterinarianResource veterinarianResource = new VeterinarianResource(stage);
+    final PetResource petResource = new PetResource(stage, queryModelStateStoreProvider.petQueries);
+    final AnimalTypeResource animalTypeResource = new AnimalTypeResource(stage, queryModelStateStoreProvider.animalTypeQueries);
+    final SpecialtyTypeResource specialtyTypeResource = new SpecialtyTypeResource(stage, queryModelStateStoreProvider.specialtyTypeQueries);
+    final ClientResource clientResource = new ClientResource(stage, queryModelStateStoreProvider.clientQueries);
+    final VeterinarianResource veterinarianResource = new VeterinarianResource(stage, queryModelStateStoreProvider.veterinarianQueries);
 
     Resources allResources = Resources.are(
         petResource.routes(),

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/AnimalTypeProjectionActor.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/AnimalTypeProjectionActor.java
@@ -1,9 +1,8 @@
 package io.vlingo.developers.petclinic.infrastructure.persistence;
 
 import io.vlingo.developers.petclinic.infrastructure.AnimalTypeData;
-import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeRenamed;
 import io.vlingo.developers.petclinic.infrastructure.Events;
-
+import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeRenamed;
 import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeTreatmentOffered;
 import io.vlingo.lattice.model.projection.Projectable;
 import io.vlingo.lattice.model.projection.StateStoreProjectionActor;
@@ -17,10 +16,6 @@ import io.vlingo.symbio.store.state.StateStore;
  * </a>
  */
 public class AnimalTypeProjectionActor extends StateStoreProjectionActor<AnimalTypeData> {
-
-  public AnimalTypeProjectionActor() {
-    super(QueryModelStateStoreProvider.instance().store);
-  }
 
   public AnimalTypeProjectionActor(final StateStore stateStore) {
     super(stateStore);

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/ClientProjectionActor.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/ClientProjectionActor.java
@@ -1,13 +1,12 @@
 package io.vlingo.developers.petclinic.infrastructure.persistence;
 
+import io.vlingo.developers.petclinic.infrastructure.ClientData;
 import io.vlingo.developers.petclinic.infrastructure.ContactInformationData;
 import io.vlingo.developers.petclinic.infrastructure.Events;
 import io.vlingo.developers.petclinic.infrastructure.FullnameData;
 import io.vlingo.developers.petclinic.model.client.ClientContactInformationChanged;
 import io.vlingo.developers.petclinic.model.client.ClientNameChanged;
 import io.vlingo.developers.petclinic.model.client.ClientRegistered;
-import io.vlingo.developers.petclinic.infrastructure.ClientData;
-
 import io.vlingo.lattice.model.projection.Projectable;
 import io.vlingo.lattice.model.projection.StateStoreProjectionActor;
 import io.vlingo.symbio.Source;
@@ -20,10 +19,6 @@ import io.vlingo.symbio.store.state.StateStore;
  * </a>
  */
 public class ClientProjectionActor extends StateStoreProjectionActor<ClientData> {
-
-  public ClientProjectionActor() {
-    super(QueryModelStateStoreProvider.instance().store);
-  }
 
   public ClientProjectionActor(StateStore stateStore) {
     super(stateStore);

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/CommandModelJournalProvider.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/CommandModelJournalProvider.java
@@ -1,54 +1,33 @@
 package io.vlingo.developers.petclinic.infrastructure.persistence;
 
-import java.util.Arrays;
-import java.util.List;
-
-import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyTypeOffered;
-import io.vlingo.developers.petclinic.model.veterinarian.VeterinarianRegistered;
-import io.vlingo.developers.petclinic.model.veterinarian.VeterinarianNameChanged;
-import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyTypeRenamed;
-import io.vlingo.developers.petclinic.model.veterinarian.VeterinarianSpecialtyChosen;
-import io.vlingo.developers.petclinic.model.pet.PetNameChanged;
-import io.vlingo.developers.petclinic.model.pet.PetDeathRecorded;
-import io.vlingo.developers.petclinic.model.pet.PetKindCorrected;
-import io.vlingo.developers.petclinic.model.client.ClientNameChanged;
-import io.vlingo.developers.petclinic.model.veterinarian.VeterinarianContactInformationChanged;
-import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeRenamed;
-import io.vlingo.developers.petclinic.model.pet.PetEntity;
-import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeTreatmentOffered;
-import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeEntity;
-import io.vlingo.developers.petclinic.model.client.ClientEntity;
-import io.vlingo.developers.petclinic.model.client.ClientContactInformationChanged;
-import io.vlingo.developers.petclinic.model.pet.PetBirthRecorded;
-import io.vlingo.developers.petclinic.model.veterinarian.VeterinarianEntity;
-import io.vlingo.developers.petclinic.model.pet.PetOwnerChanged;
-import io.vlingo.developers.petclinic.model.client.ClientRegistered;
-import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyTypeEntity;
-import io.vlingo.developers.petclinic.model.pet.PetRegistered;
-
-import io.vlingo.actors.Definition;
 import io.vlingo.actors.Stage;
+import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeEntity;
+import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeRenamed;
+import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeTreatmentOffered;
+import io.vlingo.developers.petclinic.model.client.ClientContactInformationChanged;
+import io.vlingo.developers.petclinic.model.client.ClientEntity;
+import io.vlingo.developers.petclinic.model.client.ClientNameChanged;
+import io.vlingo.developers.petclinic.model.client.ClientRegistered;
+import io.vlingo.developers.petclinic.model.pet.*;
+import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyTypeEntity;
+import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyTypeOffered;
+import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyTypeRenamed;
+import io.vlingo.developers.petclinic.model.veterinarian.*;
 import io.vlingo.lattice.model.sourcing.SourcedTypeRegistry;
 import io.vlingo.lattice.model.sourcing.SourcedTypeRegistry.Info;
 import io.vlingo.symbio.EntryAdapterProvider;
 import io.vlingo.symbio.store.dispatch.Dispatcher;
 import io.vlingo.symbio.store.dispatch.NoOpDispatcher;
-import io.vlingo.symbio.store.dispatch.DispatcherControl;
-import io.vlingo.symbio.store.dispatch.Dispatchable;
 import io.vlingo.symbio.store.journal.Journal;
 import io.vlingo.xoom.actors.Settings;
+import io.vlingo.xoom.annotation.persistence.Persistence.StorageType;
 import io.vlingo.xoom.storage.Model;
 import io.vlingo.xoom.storage.StoreActorBuilder;
-import io.vlingo.xoom.annotation.persistence.Persistence.StorageType;
+
+import java.util.Arrays;
 
 public class CommandModelJournalProvider  {
-  private static CommandModelJournalProvider instance;
-
   public final Journal<String> journal;
-
-  public static CommandModelJournalProvider  instance() {
-    return instance;
-  }
 
   public static CommandModelJournalProvider using(final Stage stage, final SourcedTypeRegistry registry) {
     return using(stage, registry, new NoOpDispatcher());
@@ -56,9 +35,6 @@ public class CommandModelJournalProvider  {
 
   @SuppressWarnings({ "unchecked", "unused" })
   public static CommandModelJournalProvider using(final Stage stage, final SourcedTypeRegistry registry, final Dispatcher ...dispatchers) {
-    if (instance != null) {
-      return instance;
-    }
 
     final EntryAdapterProvider entryAdapterProvider = EntryAdapterProvider.instance(stage.world());
 
@@ -89,9 +65,7 @@ public class CommandModelJournalProvider  {
     registry.register(new Info(journal, SpecialtyTypeEntity.class, SpecialtyTypeEntity.class.getSimpleName()));
     registry.register(new Info(journal, PetEntity.class, PetEntity.class.getSimpleName()));
 
-    instance = new CommandModelJournalProvider(journal);
-
-    return instance;
+    return new CommandModelJournalProvider(journal);
   }
 
   private CommandModelJournalProvider(final Journal<String> journal) {

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/PetProjectionActor.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/PetProjectionActor.java
@@ -16,10 +16,6 @@ import io.vlingo.symbio.store.state.StateStore;
  */
 public class PetProjectionActor extends StateStoreProjectionActor<PetData> {
 
-  public PetProjectionActor() {
-    super(QueryModelStateStoreProvider.instance().store);
-  }
-
   public PetProjectionActor(final StateStore store) {
     super(store);
   }

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/ProjectionDispatcherProvider.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/ProjectionDispatcherProvider.java
@@ -2,6 +2,7 @@ package io.vlingo.developers.petclinic.infrastructure.persistence;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import io.vlingo.actors.Definition;
 import io.vlingo.actors.Protocols;
@@ -31,25 +32,19 @@ import io.vlingo.developers.petclinic.model.pet.PetRegistered;
 
 @SuppressWarnings("rawtypes")
 public class ProjectionDispatcherProvider {
-  private static ProjectionDispatcherProvider instance;
 
   public final ProjectionDispatcher projectionDispatcher;
   public final Dispatcher storeDispatcher;
 
-  public static ProjectionDispatcherProvider instance() {
-    return instance;
-  }
-
-  public static ProjectionDispatcherProvider using(final Stage stage) {
-    if (instance != null) return instance;
+  public static ProjectionDispatcherProvider using(final Stage stage, QueryModelStateStoreProvider queryModelStateStoreProvider) {
 
     final List<ProjectToDescription> descriptions =
             Arrays.asList(
-                    ProjectToDescription.with(SpecialtyTypeProjectionActor.class, SpecialtyTypeOffered.class.getName(), SpecialtyTypeRenamed.class.getName()),
-                    ProjectToDescription.with(AnimalTypeProjectionActor.class, AnimalTypeRenamed.class.getName(), AnimalTypeTreatmentOffered.class.getName()),
-                    ProjectToDescription.with(VeterinarianProjectionActor.class, VeterinarianContactInformationChanged.class.getName(), VeterinarianSpecialtyChosen.class.getName(), VeterinarianRegistered.class.getName(), VeterinarianNameChanged.class.getName()),
-                    ProjectToDescription.with(ClientProjectionActor.class, ClientRegistered.class.getName(), ClientNameChanged.class.getName(), ClientContactInformationChanged.class.getName()),
-                    ProjectToDescription.with(PetProjectionActor.class, PetKindCorrected.class.getName(), PetNameChanged.class.getName(), PetRegistered.class.getName(), PetDeathRecorded.class.getName(), PetOwnerChanged.class.getName(), PetBirthRecorded.class.getName())
+                    ProjectToDescription.with(SpecialtyTypeProjectionActor.class, Optional.of(queryModelStateStoreProvider.store), SpecialtyTypeOffered.class.getName(), SpecialtyTypeRenamed.class.getName()),
+                    ProjectToDescription.with(AnimalTypeProjectionActor.class, Optional.of(queryModelStateStoreProvider.store), AnimalTypeRenamed.class.getName(), AnimalTypeTreatmentOffered.class.getName()),
+                    ProjectToDescription.with(VeterinarianProjectionActor.class, Optional.of(queryModelStateStoreProvider.store), VeterinarianContactInformationChanged.class.getName(), VeterinarianSpecialtyChosen.class.getName(), VeterinarianRegistered.class.getName(), VeterinarianNameChanged.class.getName()),
+                    ProjectToDescription.with(ClientProjectionActor.class, Optional.of(queryModelStateStoreProvider.store), ClientRegistered.class.getName(), ClientNameChanged.class.getName(), ClientContactInformationChanged.class.getName()),
+                    ProjectToDescription.with(PetProjectionActor.class, Optional.of(queryModelStateStoreProvider.store), PetKindCorrected.class.getName(), PetNameChanged.class.getName(), PetRegistered.class.getName(), PetDeathRecorded.class.getName(), PetOwnerChanged.class.getName(), PetBirthRecorded.class.getName())
                     );
 
     final Protocols dispatcherProtocols =
@@ -59,9 +54,7 @@ public class ProjectionDispatcherProvider {
 
     final Protocols.Two<Dispatcher, ProjectionDispatcher> dispatchers = Protocols.two(dispatcherProtocols);
 
-    instance = new ProjectionDispatcherProvider(dispatchers._1, dispatchers._2);
-
-    return instance;
+    return new ProjectionDispatcherProvider(dispatchers._1, dispatchers._2);
   }
 
   private ProjectionDispatcherProvider(final Dispatcher storeDispatcher, final ProjectionDispatcher projectionDispatcher) {

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/QueryModelStateStoreProvider.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/QueryModelStateStoreProvider.java
@@ -1,58 +1,21 @@
 package io.vlingo.developers.petclinic.infrastructure.persistence;
 
-import java.util.Arrays;
-import java.util.List;
-
-import io.vlingo.developers.petclinic.infrastructure.OwnerData;
-import io.vlingo.developers.petclinic.infrastructure.persistence.AnimalTypeQueriesActor;
-import io.vlingo.developers.petclinic.infrastructure.ContactInformationData;
-import io.vlingo.developers.petclinic.model.animaltype.AnimalTypeEntity;
-import io.vlingo.developers.petclinic.infrastructure.PetData;
-import io.vlingo.developers.petclinic.infrastructure.persistence.AnimalTypeQueries;
-import io.vlingo.developers.petclinic.infrastructure.persistence.PetQueriesActor;
-import io.vlingo.developers.petclinic.infrastructure.SpecialtyTypeData;
-import io.vlingo.developers.petclinic.infrastructure.persistence.SpecialtyTypeQueriesActor;
-import io.vlingo.developers.petclinic.infrastructure.persistence.VeterinarianQueries;
-import io.vlingo.developers.petclinic.model.veterinarian.VeterinarianEntity;
-import io.vlingo.developers.petclinic.infrastructure.PostalAddressData;
-import io.vlingo.developers.petclinic.infrastructure.FullnameData;
-import io.vlingo.developers.petclinic.infrastructure.AnimalTypeData;
-import io.vlingo.developers.petclinic.infrastructure.persistence.PetQueries;
-import io.vlingo.developers.petclinic.infrastructure.SpecialtyData;
-import io.vlingo.developers.petclinic.infrastructure.persistence.VeterinarianQueriesActor;
-import io.vlingo.developers.petclinic.infrastructure.persistence.SpecialtyTypeQueries;
-import io.vlingo.developers.petclinic.infrastructure.VisitData;
-import io.vlingo.developers.petclinic.infrastructure.NameData;
-import io.vlingo.developers.petclinic.infrastructure.persistence.ClientQueriesActor;
-import io.vlingo.developers.petclinic.infrastructure.KindData;
-import io.vlingo.developers.petclinic.infrastructure.persistence.ClientQueries;
-import io.vlingo.developers.petclinic.model.pet.PetEntity;
-import io.vlingo.developers.petclinic.infrastructure.VeterinarianData;
-import io.vlingo.developers.petclinic.infrastructure.TelephoneData;
-import io.vlingo.developers.petclinic.model.client.ClientEntity;
-import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyTypeEntity;
-import io.vlingo.developers.petclinic.infrastructure.ClientData;
-
-import io.vlingo.actors.Definition;
-import io.vlingo.actors.Protocols;
 import io.vlingo.actors.Stage;
-import io.vlingo.symbio.store.state.StateTypeStateStoreMap;
+import io.vlingo.developers.petclinic.infrastructure.*;
 import io.vlingo.lattice.model.stateful.StatefulTypeRegistry;
 import io.vlingo.symbio.EntryAdapterProvider;
 import io.vlingo.symbio.store.dispatch.Dispatcher;
 import io.vlingo.symbio.store.dispatch.NoOpDispatcher;
-import io.vlingo.symbio.store.dispatch.DispatcherControl;
-import io.vlingo.symbio.store.dispatch.Dispatchable;
 import io.vlingo.symbio.store.state.StateStore;
+import io.vlingo.symbio.store.state.StateTypeStateStoreMap;
 import io.vlingo.xoom.actors.Settings;
+import io.vlingo.xoom.annotation.persistence.Persistence.StorageType;
 import io.vlingo.xoom.storage.Model;
 import io.vlingo.xoom.storage.StoreActorBuilder;
-import io.vlingo.xoom.annotation.persistence.Persistence.StorageType;
 
+import java.util.Arrays;
 
 public class QueryModelStateStoreProvider {
-  private static QueryModelStateStoreProvider instance;
-
   public final StateStore store;
   public final SpecialtyTypeQueries specialtyTypeQueries;
   public final AnimalTypeQueries animalTypeQueries;
@@ -60,19 +23,12 @@ public class QueryModelStateStoreProvider {
   public final ClientQueries clientQueries;
   public final PetQueries petQueries;
 
-  public static QueryModelStateStoreProvider instance() {
-    return instance;
-  }
-
   public static QueryModelStateStoreProvider using(final Stage stage, final StatefulTypeRegistry registry) {
     return using(stage, registry, new NoOpDispatcher());
   }
 
   @SuppressWarnings("rawtypes")
   public static QueryModelStateStoreProvider using(final Stage stage, final StatefulTypeRegistry registry, final Dispatcher ...dispatchers) {
-    if (instance != null) {
-      return instance;
-    }
 
     new EntryAdapterProvider(stage.world()); // future use
 
@@ -95,9 +51,7 @@ public class QueryModelStateStoreProvider {
             StoreActorBuilder.from(stage, Model.QUERY, Arrays.asList(dispatchers), StorageType.STATE_STORE, Settings.properties(), true);
 
 
-    instance = new QueryModelStateStoreProvider(stage, store);
-
-    return instance;
+    return new QueryModelStateStoreProvider(stage, store);
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/SpecialtyTypeProjectionActor.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/SpecialtyTypeProjectionActor.java
@@ -18,10 +18,6 @@ import io.vlingo.symbio.store.state.StateStore;
  */
 public class SpecialtyTypeProjectionActor extends StateStoreProjectionActor<SpecialtyTypeData> {
 
-  public SpecialtyTypeProjectionActor() {
-    super(QueryModelStateStoreProvider.instance().store);
-  }
-
   public SpecialtyTypeProjectionActor(final StateStore stateStore) {
     super(stateStore);
   }

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/VeterinarianProjectionActor.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/persistence/VeterinarianProjectionActor.java
@@ -16,10 +16,6 @@ import io.vlingo.symbio.store.state.StateStore;
  */
 public class VeterinarianProjectionActor extends StateStoreProjectionActor<VeterinarianData> {
 
-  public VeterinarianProjectionActor() {
-    super(QueryModelStateStoreProvider.instance().store);
-  }
-
   public VeterinarianProjectionActor(StateStore stateStore) {
     super(stateStore);
   }

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/AnimalTypeResource.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/AnimalTypeResource.java
@@ -24,9 +24,9 @@ import static io.vlingo.http.ResponseHeader.*;
 public class AnimalTypeResource extends DynamicResourceHandler {
   private final AnimalTypeQueries $queries;
 
-  public AnimalTypeResource(final Stage stage) {
+  public AnimalTypeResource(final Stage stage, final AnimalTypeQueries animalTypeQueries) {
       super(stage);
-      this.$queries = QueryModelStateStoreProvider.instance().animalTypeQueries;
+      this.$queries = animalTypeQueries;
   }
 
   public Completes<Response> rename(final String id, final AnimalTypeData data) {

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/ClientResource.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/ClientResource.java
@@ -26,9 +26,9 @@ import static io.vlingo.http.ResponseHeader.*;
 public class ClientResource extends DynamicResourceHandler {
   private final ClientQueries $queries;
 
-  public ClientResource(final Stage stage) {
+  public ClientResource(final Stage stage, final ClientQueries clientQueries) {
       super(stage);
-      this.$queries = QueryModelStateStoreProvider.instance().clientQueries;
+      this.$queries = clientQueries;
   }
 
   public Completes<Response> changeName(final String id, final ClientData data) {

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/PetResource.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/PetResource.java
@@ -27,9 +27,9 @@ import static io.vlingo.http.ResponseHeader.*;
 public class PetResource extends DynamicResourceHandler {
   private final PetQueries $queries;
 
-  public PetResource(final Stage stage) {
+  public PetResource(final Stage stage, final PetQueries petQueries) {
       super(stage);
-      this.$queries = QueryModelStateStoreProvider.instance().petQueries;
+      this.$queries = petQueries;
   }
 
   public Completes<Response> changeName(final String id, final PetData data) {

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/SpecialtyTypeResource.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/SpecialtyTypeResource.java
@@ -2,21 +2,19 @@ package io.vlingo.developers.petclinic.infrastructure.resource;
 
 import io.vlingo.actors.Definition;
 import io.vlingo.actors.Stage;
-import io.vlingo.http.resource.Resource;
-import io.vlingo.http.resource.DynamicResourceHandler;
-import static io.vlingo.http.resource.ResourceBuilder.resource;
-
+import io.vlingo.common.Completes;
 import io.vlingo.developers.petclinic.infrastructure.SpecialtyTypeData;
 import io.vlingo.developers.petclinic.infrastructure.persistence.SpecialtyTypeQueries;
 import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyType;
 import io.vlingo.developers.petclinic.model.specialtytype.SpecialtyTypeEntity;
-import io.vlingo.developers.petclinic.infrastructure.persistence.QueryModelStateStoreProvider;
-
 import io.vlingo.http.Response;
-import io.vlingo.common.Completes;
+import io.vlingo.http.resource.DynamicResourceHandler;
+import io.vlingo.http.resource.Resource;
+
 import static io.vlingo.common.serialization.JsonSerialization.serialized;
 import static io.vlingo.http.Response.Status.*;
 import static io.vlingo.http.ResponseHeader.*;
+import static io.vlingo.http.resource.ResourceBuilder.resource;
 
 /**
  * See <a href="https://docs.vlingo.io/vlingo-xoom/xoom-annotations#resourcehandlers">@ResourceHandlers</a>
@@ -24,9 +22,9 @@ import static io.vlingo.http.ResponseHeader.*;
 public class SpecialtyTypeResource extends DynamicResourceHandler {
   private final SpecialtyTypeQueries $queries;
 
-  public SpecialtyTypeResource(final Stage stage) {
+  public SpecialtyTypeResource(final Stage stage, final SpecialtyTypeQueries specialtyTypeQueries) {
       super(stage);
-      this.$queries = QueryModelStateStoreProvider.instance().specialtyTypeQueries;
+      this.$queries = specialtyTypeQueries;
   }
 
   public Completes<Response> rename(final String id, final SpecialtyTypeData data) {

--- a/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/VeterinarianResource.java
+++ b/vlingo-petclinic/src/main/java/io/vlingo/developers/petclinic/infrastructure/resource/VeterinarianResource.java
@@ -27,9 +27,9 @@ import static io.vlingo.http.ResponseHeader.*;
 public class VeterinarianResource extends DynamicResourceHandler {
   private final VeterinarianQueries $queries;
 
-  public VeterinarianResource(final Stage stage) {
+  public VeterinarianResource(final Stage stage, final VeterinarianQueries veterinarianQueries) {
       super(stage);
-      this.$queries = QueryModelStateStoreProvider.instance().veterinarianQueries;
+      this.$queries = veterinarianQueries;
   }
 
   public Completes<Response> changeName(final String id, final VeterinarianData data) {


### PR DESCRIPTION
I noticed that tests are failing due to state leaking between test cases. I've seen this problem before in other examples and I think it can be easily avoided by changing the approach rather than trying to clear the global state between test runs.

As far as I noticed there is no need for providers to be singletons, so I suggest we pass dependencies explicitly. This way we're not only going to prevent hard-to-track test failures, but also make the code easier to follow.

By passing dependencies explicitly it's easy to see where various dependencies are used, and how they're initialised just by looking at the Bootstrap class.

If this is accepted, I'm happy to work on a similar change in Xoom / Xoom Starter.